### PR TITLE
Bug Fix: MySQL Connection Fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_HOST = 
+DB_USER = 
+DB_PASSWORD = 
+DB_NAME = burgers_db

--- a/config/connection.js
+++ b/config/connection.js
@@ -7,8 +7,6 @@ let password = process.env.DB_PASSWORD;
 let database = process.env.DB_NAME;
 let connection;
 
-console.log(host, user, password, database)
-
 if (process.env.JAWSDB_URL) {
   // Connect DB on Heroku (JawsDB)
   connection = mysql.createConnection(process.env.JAWSDB_URL);

--- a/config/connection.js
+++ b/config/connection.js
@@ -1,18 +1,24 @@
 // Import the dependencies
+require('dotenv').config();
 const mysql = require("mysql");
-const dotenv = require("dotenv").config();
+let host = process.env.DB_HOST;
+let user = process.env.DB_USER;
+let password = process.env.DB_PASSWORD;
+let database = process.env.DB_NAME;
+let connection;
+
+console.log(host, user, password, database)
 
 if (process.env.JAWSDB_URL) {
   // Connect DB on Heroku (JawsDB)
   connection = mysql.createConnection(process.env.JAWSDB_URL);
 } else {
   // Connect to the DB on localhost
-  const connection = mysql.createConnection({
-    host: process.env.DB_HOST,
-    port: 3306,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASS,
-    database: "burgers_db"
+  connection = mysql.createConnection({
+    host,
+    user,
+    password,
+    database
   });
 };
 


### PR DESCRIPTION
This should definitely fix your problem with the MySQL Connection on both local and Heroku. Just make sure that your Heroku `JawsDB_URL` variable is exactly that!

You can double check by running `heroku config` in your project directory once you connect it to Heroku with `heroku create`

For me, my config spits out `JAWSDB_MARIA_URL` because I chose the MariaDB instance ass opposed to the MySQL instance.